### PR TITLE
fix: raising import error when not install using discord extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ LOGGING = {
         }
     },
     "loggers": {
-        "easy": {
+        "logcaster": {
             "handlers": ["telegram", "discord"],
             "formatters": ["telegram_fmt", "discord_fmt"],
             "level": "ERROR",

--- a/logcaster/discord.py
+++ b/logcaster/discord.py
@@ -1,4 +1,91 @@
-from .formatters import DiscordFormatter
-from .handlers import DiscordHandler
+import logging
+import sys
+
+from discord_webhook import DiscordEmbed, DiscordWebhook
+
+from .formatters import BaseFormatter
+from .handlers import BaseHandler
+from .settings import ENV
+
+
+class DiscordFormatter(BaseFormatter):
+    def __init__(self, *args, **kwargs):
+        self.author = kwargs.pop('author', 'Logcaster')
+        self.thumbnail = kwargs.pop('thumbnail_url', None)
+        self.image = kwargs.pop('image_url', None)
+
+        super().__init__(*args, **kwargs)
+
+        self.COLORS = {
+            logging.DEBUG: "3498db",  # blue
+            logging.INFO: "2ecc71",  # green
+            logging.WARNING: "f1c40f",  # yellow
+            logging.ERROR: "e74c3c",  # red
+            logging.CRITICAL: "8e44ad",  # purple
+        }
+                
+        self.EMOJIS = {
+            logging.DEBUG: "\U0001f41b",  # 🐛
+            logging.INFO: "\U0001f4ac",  # 💬
+            logging.WARNING: "\U000026a0",  # ⚠️
+            logging.ERROR: "\U00002757",  # ❗
+            logging.CRITICAL: "\U0001f4a5",  # 💥
+        }
+
+        self.RESET = "\033[0m"
+
+    def _get_emoji(self, record):
+        return self.EMOJIS.get(record.levelno, "")
+
+    def _get_level_name_with_emoji(self, record):
+        emoji = self._get_emoji(record)
+        levelname = f"{emoji} {record.levelname} {emoji}"
+        return levelname
+    
+    def _get_color(self, record: logging.LogRecord) -> str:
+        """return the hex color by the record.levelno attribute"""
+        return self.COLORS.get(record.levelno, logging.INFO)
+
+    def format(self, record: logging.LogRecord) -> DiscordEmbed:
+        embed = DiscordEmbed(
+            title=self._get_level_name_with_emoji(record),
+            description=record.getMessage(),
+            color=self._get_color(record),
+        )
+
+        self.thumbnail and embed.set_thumbnail(self.thumbnail)
+        self.image and embed.set_image(self.image)
+
+        embed.set_author(name=self.author)
+
+        embed.set_footer(text="powered by @Low")
+        embed.set_timestamp()
+
+        data = self._get_fields(record)
+        [embed.add_embed_field(name=field, value=str(value)) for field, value in data.items()]
+        return embed
+
+
+class DiscordHandler(BaseHandler):
+    def get_webhook(self) -> DiscordWebhook:
+        return DiscordWebhook(ENV.discord.webhook_url)
+    
+    def emit(self, record: logging.LogRecord) -> None:
+        webhook = self.get_webhook()
+
+        fmt = self.format(record)
+        if isinstance(fmt, DiscordEmbed):
+            webhook.add_embed(fmt)
+        else:
+            webhook.content = fmt
+        
+        try:
+            webhook.execute()
+            sys.stdout.write('logger sent to discord\n')
+        
+        except Exception as e:
+            sys.stderr.write('fail to sending logging to Discord: %s\n' % str(e))
+            sys.stderr.write(f'lost message: {record.getMessage()}')
+
 
 __all__ = ['DiscordHandler', 'DiscordFormatter']

--- a/logcaster/formatters.py
+++ b/logcaster/formatters.py
@@ -1,6 +1,4 @@
 import logging
-from tabulate import tabulate
-from discord_webhook import DiscordEmbed
 
 
 class BaseFormatter(logging.Formatter):
@@ -31,74 +29,4 @@ class BaseFormatter(logging.Formatter):
         return {key: value for key, value in record_dict.items() if key not in self.exclude_fields}
 
 
-class DiscordFormatter(BaseFormatter):
-    def __init__(self, *args, **kwargs):
-        self.author = kwargs.pop('author', 'Logcaster')
-        self.thumbnail = kwargs.pop('thumbnail_url', None)
-        self.image = kwargs.pop('image_url', None)
-
-        super().__init__(*args, **kwargs)
-
-        self.COLORS = {
-            logging.DEBUG: "3498db",  # blue
-            logging.INFO: "2ecc71",  # green
-            logging.WARNING: "f1c40f",  # yellow
-            logging.ERROR: "e74c3c",  # red
-            logging.CRITICAL: "8e44ad",  # purple
-        }
-                
-        self.EMOJIS = {
-            logging.DEBUG: "\U0001f41b",  # 🐛
-            logging.INFO: "\U0001f4ac",  # 💬
-            logging.WARNING: "\U000026a0",  # ⚠️
-            logging.ERROR: "\U00002757",  # ❗
-            logging.CRITICAL: "\U0001f4a5",  # 💥
-        }
-
-        self.RESET = "\033[0m"
-
-    def _get_emoji(self, record):
-        return self.EMOJIS.get(record.levelno, "")
-
-    def _get_level_name_with_emoji(self, record):
-        emoji = self._get_emoji(record)
-        levelname = f"{emoji} {record.levelname} {emoji}"
-        return levelname
-    
-    def _get_color(self, record: logging.LogRecord) -> str:
-        """return the hex color by the record.levelno attribute"""
-        return self.COLORS.get(record.levelno, logging.INFO)
-
-    def format(self, record: logging.LogRecord) -> DiscordEmbed:
-        embed = DiscordEmbed(
-            title=self._get_level_name_with_emoji(record),
-            description=record.getMessage(),
-            color=self._get_color(record),
-        )
-
-        self.thumbnail and embed.set_thumbnail(self.thumbnail)
-        self.image and embed.set_image(self.image)
-
-        embed.set_author(name=self.author)
-
-        embed.set_footer(text="powered by @Low")
-        embed.set_timestamp()
-
-        data = self._get_fields(record)
-        [embed.add_embed_field(name=field, value=str(value)) for field, value in data.items()]
-        return embed
-
-
-class TelegramFormatter(BaseFormatter):
-    def __init__(self, include_fields=None, exclude_fields=None):
-        super().__init__()
-        self.include_fields = include_fields or []
-        self.exclude_fields = exclude_fields or []
-
-    def format(self, record):
-        data = self._get_fields(record)
-        table = tabulate(data.items(), tablefmt='presto', headers=['field', 'value'])
-        return table
-
-
-__all__ = ['DiscordFormatter', 'TelegramFormatter']
+__all__ = ['BaseFormatter']

--- a/logcaster/handlers.py
+++ b/logcaster/handlers.py
@@ -1,12 +1,4 @@
-import json
 import logging
-import sys
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
-
-from discord_webhook import DiscordEmbed, DiscordWebhook
-
-from .settings import ENV
 
 
 class BaseHandler(logging.Handler):
@@ -14,57 +6,4 @@ class BaseHandler(logging.Handler):
         super().__init__(level)
 
 
-class DiscordHandler(BaseHandler):
-    def get_webhook(self) -> DiscordWebhook:
-        return DiscordWebhook(ENV.discord.webhook_url)
-    
-    def emit(self, record: logging.LogRecord) -> None:
-        webhook = self.get_webhook()
-
-        fmt = self.format(record)
-        if isinstance(fmt, DiscordEmbed):
-            webhook.add_embed(fmt)
-        else:
-            webhook.content = fmt
-        
-        try:
-            webhook.execute()
-            sys.stdout.write('logger sent to discord\n')
-        
-        except Exception as e:
-            sys.stderr.write('fail to sending logging to Discord: %s\n' % str(e))
-            sys.stderr.write(f'lost message: {record.getMessage()}')
-
-
-class TelegramHandler(BaseHandler):
-    def emit(self, record):
-        out = self.format(record)
-        out = f"```\n{out}\n```"
-        chat_id = ENV.telegram.chat_id
-        data = json.dumps(
-            {"text": out, "chat_id": chat_id, "parse_mode": "MarkdownV2"}
-        ).encode("utf-8")
-
-        request = Request(
-            f"https://api.telegram.org/bot{ENV.telegram.bot_token}/sendMessage",
-            data=data,
-            headers={"Content-Type": "application/json"},
-        )
-
-        try:
-            urlopen(request)
-            sys.stdout.write(f"Logging sent to telegram chat id {chat_id}\n")
-
-        except HTTPError as e:
-            sys.stdout.write(f"error when logging to telegram: {e.read().decode()}\n")
-            return False
-
-        except Exception as e:
-            sys.stderr.write(f"error when logging to telegram: {str(e)}\n")
-            sys.stderr.write(out + "\n")
-            return False
-
-        return True
-
-
-__all__ = ["DiscordHandler", "TelegramHandler"]
+__all__ = ["BaseHandler"]

--- a/logcaster/telegram.py
+++ b/logcaster/telegram.py
@@ -1,4 +1,56 @@
-from .formatters import TelegramFormatter
-from .handlers import TelegramHandler
+import json
+import sys
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+from tabulate import tabulate
+
+from .formatters import BaseFormatter
+from .handlers import BaseHandler
+from .settings import ENV
+
+
+class TelegramFormatter(BaseFormatter):
+    def __init__(self, include_fields=None, exclude_fields=None):
+        super().__init__()
+        self.include_fields = include_fields or []
+        self.exclude_fields = exclude_fields or []
+
+    def format(self, record):
+        data = self._get_fields(record)
+        table = tabulate(data.items(), tablefmt='presto', headers=['field', 'value'])
+        return table
+
+
+class TelegramHandler(BaseHandler):
+    def emit(self, record):
+        out = self.format(record)
+        out = f"```\n{out}\n```"
+        chat_id = ENV.telegram.chat_id
+        data = json.dumps(
+            {"text": out, "chat_id": chat_id, "parse_mode": "MarkdownV2"}
+        ).encode("utf-8")
+
+        request = Request(
+            f"https://api.telegram.org/bot{ENV.telegram.bot_token}/sendMessage",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            urlopen(request)
+            sys.stdout.write(f"Logging sent to telegram chat id {chat_id}\n")
+
+        except HTTPError as e:
+            sys.stdout.write(f"error when logging to telegram: {e.read().decode()}\n")
+            return False
+
+        except Exception as e:
+            sys.stderr.write(f"error when logging to telegram: {str(e)}\n")
+            sys.stderr.write(out + "\n")
+            return False
+
+        return True
+
 
 __all__ = ['TelegramHandler', 'TelegramFormatter']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logcaster"
-version = "0.1.0"
+version = "0.1.1"
 description = "Logging handlers to send logs to discord and telegram"
 authors = [
     {name = "LeandroDeJesus-S",email = "jstleandro@gmail.com"}
@@ -29,8 +29,8 @@ classifiers = [
 keywords = ['logging']
 
 [project.urls]
-repository = 'https://github.com/LeandroDeJesus-S/easylog'
-issues = 'https://github.com/LeandroDeJesus-S/easylog/issues'
+repository = 'https://github.com/LeandroDeJesus-S/logcaster'
+issues = 'https://github.com/LeandroDeJesus-S/logcaster/issues'
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
-from logcaster.handlers import DiscordHandler
-from logcaster.formatters import DiscordFormatter
+from logcaster.discord import DiscordHandler, DiscordFormatter
 
 
 @pytest.fixture
@@ -30,12 +29,12 @@ def log_record() -> logging.LogRecord:
 
 @pytest.fixture
 def mock_webhook(mocker):
-    return mocker.patch("logcaster.handlers.DiscordWebhook")
+    return mocker.patch("logcaster.discord.DiscordWebhook")
 
 
 @pytest.fixture
 def mock_embed(mocker):
-    return mocker.patch("logcaster.handlers.DiscordEmbed")
+    return mocker.patch("logcaster.discord.DiscordEmbed")
 
 
 @pytest.fixture

--- a/tests/formatters/test_discord_formatters.py
+++ b/tests/formatters/test_discord_formatters.py
@@ -1,4 +1,4 @@
-from logcaster.formatters import DiscordFormatter
+from logcaster.discord import DiscordFormatter
 from discord_webhook import DiscordEmbed
 
 fmt = DiscordFormatter()

--- a/tests/formatters/test_telegram_formatter.py
+++ b/tests/formatters/test_telegram_formatter.py
@@ -1,4 +1,4 @@
-from logcaster.formatters import TelegramFormatter
+from logcaster.telegram import TelegramFormatter
 from tabulate import tabulate
 
 

--- a/tests/handlers/test_telegram_handler.py
+++ b/tests/handlers/test_telegram_handler.py
@@ -1,8 +1,8 @@
-from logcaster.handlers import TelegramHandler
+from logcaster.telegram import TelegramHandler
 
 
 def test_emit(mocker, log_record):
-    mocked_urlopen = mocker.patch('logcaster.handlers.urlopen')
+    mocked_urlopen = mocker.patch('logcaster.telegram.urlopen')
     handler = TelegramHandler()
     emitted = handler.emit(log_record)
     mocked_urlopen.assert_called_once()


### PR DESCRIPTION
I have moved the Handler and Formatter classes to the source which it belongs to, now the files `handlers` and `formatters` contains only the base class